### PR TITLE
feat: versioning, rate limiting, threshold calibration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ endif
 # ── Targets ───────────────────────────────────────────────────────────────────
 
 .PHONY: help env check install seed deploy secrets dev dev-http setup \
-        validate scan docker-up docker-down docker-seed docker-logs docker-build
+        validate scan calibrate check-qdrant-keys \
+        docker-up docker-down docker-seed docker-logs docker-build
 
 help:
 	@echo ""
@@ -41,8 +42,10 @@ help:
 	@echo "  make setup        Full first-time setup: env → install → seed → secrets → deploy"
 	@echo ""
 	@echo "  ── Security & Validation ────────────────────────────────"
-	@echo "  make validate     Validate all SKILL.md files (schema + prompt-injection)"
-	@echo "  make scan         Alias for validate"
+	@echo "  make validate          Validate all SKILL.md files (schema + prompt-injection)"
+	@echo "  make scan              Alias for validate"
+	@echo "  make calibrate         Sweep (t_high, t_low) pairs; report precision/recall"
+	@echo "  make check-qdrant-keys Warn if read/write Qdrant keys are the same"
 	@echo ""
 	@echo "  ── Docker (one-command local stack) ─────────────────────"
 	@echo "  make docker-up    Start full stack: Qdrant + seed + MCP server"
@@ -101,6 +104,32 @@ validate:
 	$(PYTHON) scripts/validate_skills.py
 
 scan: validate
+
+calibrate: check
+	$(PYTHON) -m skill_mcp.eval.calibrate --dataset tests/eval/threshold_calibration.json
+
+check-qdrant-keys:
+	@$(PYTHON) - <<'EOF'
+import os, sys
+from dotenv import load_dotenv
+load_dotenv()
+key = os.getenv("QDRANT_API_KEY", "").strip()
+ro_key = os.getenv("QDRANT_RO_API_KEY", "").strip()
+if not key:
+    print("[check-qdrant-keys] QDRANT_API_KEY is not set — nothing to check.")
+    sys.exit(0)
+if key == ro_key:
+    print("[check-qdrant-keys] WARN  QDRANT_API_KEY and QDRANT_RO_API_KEY are identical.")
+    print("                   The Worker should use a read-only key for runtime queries.")
+    print("                   Set QDRANT_RO_API_KEY in .env and push it as a Worker secret.")
+    sys.exit(1)
+if not ro_key:
+    print("[check-qdrant-keys] NOTE  QDRANT_RO_API_KEY is not set.")
+    print("                   Recommended: create a read-only Qdrant key for the Worker.")
+    print("                   See docs/ARCHITECTURE.md for details.")
+    sys.exit(0)
+print("[check-qdrant-keys] OK  QDRANT_API_KEY != QDRANT_RO_API_KEY — keys are separated.")
+EOF
 
 # ── Docker targets ─────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ No separate backend. No database server to manage. No GPU. Cloudflare Workers AI
 | Tier | Tool | When to call |
 |------|------|-------------|
 | 1 | `skills_find_relevant(query, top_k)` | **Always first**  semantic search, returns ranked skills with scores |
-| 2 | `skills_get_body(skill_id)` | After finding a match  full instructions + `tier3_manifest` |
+| 2 | `skills_get_body(skill_id, version?)` | After finding a match  full instructions + `tier3_manifest`; `version` pins to a specific release |
 | 2 | `skills_get_options(skill_id)` | Optional  config schema, variants, dependencies, limitations |
 | 3 | `skills_get_reference(skill_id, filename)` | Only when instructions reference a specific doc |
 | 3 | `skills_run_script(skill_id, filename, input_data)` | Only when instructions direct script execution |
@@ -260,7 +260,9 @@ make dev-http   # Run local FastMCP server on HTTP :8000
 make setup      # Full first-run: env + install + seed + secrets + deploy
 
 # Security & validation
-make validate   # Validate all SKILL.md files — schema + prompt-injection scan
+make validate          # Validate all SKILL.md files — schema + prompt-injection scan
+make calibrate         # Sweep (t_high, t_low) pairs; report precision/recall/F1
+make check-qdrant-keys # Warn if read/write Qdrant keys are identical
 
 # Docker (one-command local stack)
 make docker-up    # Start Qdrant + seed + MCP server
@@ -307,7 +309,7 @@ make docker-seed   # Re-seed after adding new skills
 
 ## Connecting Your AI Agent
 
-> **Before connecting to any hosted skill-mcp instance you do not control:** read [TRANSPARENCY.md](TRANSPARENCY.md). Skill bodies load directly into your agent's context window from a third-party server. The hosted instance offered by this repo is a personal deployment with no SLA, no authentication, and no rate limiting. For production use or sensitive workloads, self-host.
+> **Before connecting to any hosted skill-mcp instance you do not control:** read [TRANSPARENCY.md](TRANSPARENCY.md). Skill bodies load directly into your agent's context window from a third-party server. The hosted instance offered by this repo is a personal deployment with no SLA and no authentication. For production use or sensitive workloads, self-host.
 
 ### Step 1  Add the MCP server
 
@@ -460,6 +462,8 @@ Full threat model: [`THREAT_MODEL.md`](THREAT_MODEL.md) · Hosted instance trust
 
 ### Runtime hardening (Worker + local server)
 
+- **Per-IP rate limiting** — 60 requests/minute sliding window (configurable via `RATE_LIMIT_RPM`); returns HTTP 429 when exceeded; stale entry eviction at 10k IPs; Worker-only
+- **CORS headers** — `Access-Control-Allow-Origin: *` on all Worker responses; supports browser-based MCP clients and testers (Glama, MCP Inspector)
 - **1 MB request body limit** — POST bodies over 1 MB rejected with HTTP 413 before parsing
 - **Sanitized error messages** — upstream URLs, Qdrant responses, and stack traces never reach MCP clients
 - **Security response headers** — `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Cache-Control: no-store`, `Referrer-Policy: no-referrer`
@@ -494,6 +498,7 @@ Three top-level directories own three distinct concerns:
 skill-mcp/
 ├── skill_mcp/                     # Installable Python package (pip install -e ".[seed]")
 │   ├── db/                        # Qdrant client, embedder, TTL cache
+│   ├── eval/calibrate.py          # Threshold calibration runner (precision/recall sweep)
 │   ├── models/skill.py            # Pydantic models for all 6 collection types
 │   ├── security/prompt_injection.py  # 9-category injection scanner
 │   ├── seed/seed_skills.py        # Walks skills_data/, scans, embeds, upserts Qdrant
@@ -501,7 +506,7 @@ skill-mcp/
 │   ├── skills_data/               # 30 skill folders — one SKILL.md each
 │   └── server.py                  # Local FastMCP entry point (stdio / HTTP)
 ├── src/
-│   └── worker.py                  # Cloudflare Python Worker — all 6 tools, SSE transport
+│   └── worker.py                  # Cloudflare Python Worker — all 6 tools, SSE + Streamable HTTP, rate limiting, CORS
 ├── scripts/
 │   ├── setup.sh / setup.ps1       # One-shot setup wizards (Linux/macOS + Windows)
 │   └── validate_skills.py         # SKILL.md validator — schema + injection scan
@@ -514,7 +519,8 @@ skill-mcp/
 │       ├── cline/.clinerules
 │       ├── copilot/.github/copilot-instructions.md
 │       └── aider/CONVENTIONS.md
-├── tests/                         # pytest unit + integration tests
+├── tests/
+│   └── eval/threshold_calibration.json  # 120 eval triples for threshold calibration
 ├── .github/workflows/
 │   ├── tests.yml                  # pytest on every push (unit tests, no external deps)
 │   └── validate-skills.yml        # SKILL.md lint + injection scan on PRs
@@ -539,8 +545,6 @@ skill-mcp/
 - **Token usage scales with collection size** — `skills_find_relevant` returns `top_k` result descriptors (each ~100–200 tokens). At 30 skills this is negligible. At 300+ skills with higher `top_k` values, a single discovery call can consume a meaningful share of the context window. Keep `top_k` low (3–5) and write precise, distinct trigger phrases per skill to preserve relevance at scale.
 
 - **Script execution is local-only** — `skills_run_script` requires the local Python server. The Cloudflare Worker returns the script manifest but cannot execute subprocesses — the Pyodide runtime does not support `subprocess`. Any skill workflow that calls `skills_run_script` must point the MCP client at `python -m skill_mcp.server` instead of the Worker URL.
-
-- **No built-in skill versioning** — Skills are stored as Qdrant point payloads keyed by `skill_id`. Re-seeding overwrites the previous payload with no diff or rollback. If you need to recover a prior skill state, re-seed from git history.
 
 - **Embedding model is pinned at seed time** — Vectors are generated with `@cf/baai/bge-small-en-v1.5` (384-dim) at both seed time and query time. If Cloudflare Workers AI retires or changes this model, all vectors become incomparable and the entire skill collection must be re-seeded.
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -280,6 +280,10 @@ Every response includes: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DE
 
 The Worker is behind Cloudflare's network. DDoS protection, rate limiting, and bot management are available via Cloudflare dashboard.
 
+**M-05f: Per-IP application-level rate limiting**
+
+A sliding-window rate limiter is implemented in the Durable Object closure. Default: 60 requests/minute per IP (derived from `CF-Connecting-IP` → `X-Forwarded-For` → `"unknown"`). Configurable via `RATE_LIMIT_RPM` environment variable. Returns HTTP 429 when exceeded. Stale IP entries are evicted when the store exceeds 10,000 entries. State is in-memory and resets on Worker restart — not a substitute for Cloudflare's network-level protections, but stops naive scripted abuse.
+
 ### Residual Risk
 
 The endpoint has no authentication. Anyone who knows the Worker URL can invoke tools. For production deployments with sensitive skills, consider:
@@ -294,7 +298,7 @@ The endpoint has no authentication. Anyone who knows the Worker URL can invoke t
 
 **Threat ID:** T-06  
 **Severity:** Medium  
-**Status:** Partially mitigated
+**Status:** Mitigated
 
 ### Description
 
@@ -311,9 +315,9 @@ A compromised package version could affect either the seed pipeline or the deplo
 
 The Cloudflare Worker depends only on `mcp>=1.5.0`. All outbound HTTP uses `js.fetch` (no `requests` or `urllib` in the Worker — those don't work in Pyodide anyway).
 
-**M-06b: No requirements pinning** *(known risk — unresolved)*
+**M-06b: Requirements pinned to exact versions** *(resolved)*
 
-`requirements.txt` uses `>=` version specifiers. This is a known risk. Pinning to exact versions with `pip-compile` and using Dependabot for automated updates would reduce this risk. Not yet implemented.
+`requirements.txt` now pins all seed-script and local-server dependencies to exact versions (e.g., `qdrant-client==1.17.1`, `pydantic==2.12.5`). This prevents silent upgrades from breaking the seed pipeline. Dependabot or `pip-compile` updates should be reviewed before merging.
 
 **M-06c: Pyodide sandbox**
 
@@ -362,9 +366,10 @@ The DO is necessary because Cloudflare Workers are stateless by default — each
 | Deployment | Transport | MCP spec revision |
 |------------|-----------|------------------|
 | Cloudflare Worker | SSE (`GET /sse` + `POST /messages/`) | `2024-11-05` |
-| Local Python server | `streamable-http` or `stdio` | `2024-11-05` |
+| Cloudflare Worker | Streamable HTTP (`POST /mcp`, stateless) | `2025-03-26` |
+| Local Python server | `streamable-http` or `stdio` | `2025-03-26` |
 
-The MCP specification now defines `streamable-http` as the preferred transport, superseding the SSE transport. The Worker's SSE transport is functional but represents technical debt. Migration is tracked in [CONTRIBUTING.md](CONTRIBUTING.md#4-priority-4--protocol-and-infrastructure).
+The Worker now supports both transports. The Streamable HTTP endpoint (`POST /mcp`) is stateless — it handles one JSON-RPC message per request and returns a direct response, making it compatible with browser-based testers (Glama, MCP Inspector) and newer SDK clients. CORS headers (`Access-Control-Allow-Origin: *`) are included on all responses.
 
 ---
 
@@ -400,3 +405,4 @@ Maintainers will acknowledge within 48 hours and aim to fix critical issues with
 |------|---------|--------|
 | 2026-04-26 | 1.0 | Initial threat model |
 | 2026-05-01 | 1.1 | Added Architectural Clarifications section (DO usage, transport status); updated M-04d to reflect that read/write key separation is recommended but not default; added link to TRANSPARENCY.md; corrected M-06b wording from "planned" to "known risk — unresolved" |
+| 2026-05-02 | 1.2 | Added M-05f (per-IP application-level rate limiting, 60 req/min sliding window); resolved M-06b (requirements pinned to exact versions); updated transport status table to include Streamable HTTP (`POST /mcp`) and CORS; T-06 status updated from "Partially mitigated" to "Mitigated" |

--- a/TRANSPARENCY.md
+++ b/TRANSPARENCY.md
@@ -83,12 +83,14 @@ For production environments handling sensitive tasks, self-hosting with your own
 ```
 Your AI agent (MCP client)
         │
-        │  MCP over SSE (HTTPS)
+        │  MCP over SSE or Streamable HTTP (HTTPS)
         ▼
 Cloudflare Worker (Python/Pyodide)
   — single Durable Object instance
   — holds SSE session state (in-memory, not persisted)
-  — no authentication on the /sse endpoint
+  — no authentication on any endpoint
+  — per-IP rate limiting: 60 req/min (configurable via RATE_LIMIT_RPM)
+  — CORS headers on all responses (supports browser-based MCP clients)
         │                │
         │ HTTPS REST     │ Workers AI binding
         ▼                ▼
@@ -96,9 +98,13 @@ Cloudflare Worker (Python/Pyodide)
   (6 collections)   (bge-small-en-v1.5)
 ```
 
-**There is no authentication on the `/sse` endpoint.** Anyone who knows the Worker URL can connect and call all six MCP tools. There is no per-user rate limiting beyond Cloudflare's platform-level protections.
+**There is no authentication on the `/sse` or `/mcp` endpoints.** Anyone who knows the Worker URL can connect and call all six MCP tools. A per-IP sliding-window rate limit (60 requests/minute by default, configurable via `RATE_LIMIT_RPM`) is enforced at the application level.
 
-**Transport:** The Worker uses the MCP SSE transport (`GET /sse` + `POST /messages/`). This is the MCP spec revision `2024-11-05`. Migration to `streamable-http` (the current preferred MCP transport) is tracked in [CONTRIBUTING.md](CONTRIBUTING.md#4-priority-4--protocol-and-infrastructure).
+**Transports:** The Worker supports two MCP transports:
+- **SSE** (`GET /sse` + `POST /messages/`) — MCP spec revision `2024-11-05`; used by Claude Desktop and Claude.ai
+- **Streamable HTTP** (`POST /mcp`, stateless) — MCP spec revision `2025-03-26`; used by browser-based testers (Glama, MCP Inspector) and newer SDK clients
+
+CORS headers (`Access-Control-Allow-Origin: *`) are included on all responses to support browser-based clients.
 
 ---
 
@@ -117,11 +123,13 @@ Connecting an AI agent to any external MCP server — including this one — mea
 
 ## Rate Limiting and Abuse Prevention
 
-The hosted instance has **no application-level rate limiting**. Platform-level protections from Cloudflare (DDoS mitigation, automated bot scoring) are active, but there is no per-IP or per-session request throttle in the Worker code.
+The hosted instance enforces a **per-IP sliding-window rate limit of 60 requests/minute** at the application level. The limit is configurable via the `RATE_LIMIT_RPM` environment variable for self-hosted deployments. When the limit is exceeded, the Worker returns HTTP 429. The rate state is held in the Durable Object closure and is not persisted — it resets on Worker restart.
 
-If abuse causes the free-tier Cloudflare limits (100k requests/day) to be exceeded, the instance will stop responding until the next day's quota resets.
+Cloudflare platform-level protections (DDoS mitigation, automated bot scoring) are also active.
 
-For teams or high-frequency workflows, self-host to avoid shared quota exhaustion.
+If sustained abuse causes the free-tier Cloudflare limits (100k requests/day) to be exceeded, the instance will stop responding until the next day's quota resets.
+
+For teams or high-frequency workflows, self-host to avoid shared quota exhaustion and to set your own rate limit.
 
 ---
 
@@ -129,12 +137,12 @@ For teams or high-frequency workflows, self-host to avoid shared quota exhaustio
 
 When skills in this repository are updated and the seed script is re-run:
 
-- The Qdrant payloads for updated skills are **overwritten** with no diff or rollback
-- There is no version history in Qdrant — the previous skill body is gone
+- The **latest-alias** Qdrant point for each skill is overwritten with the new content
+- A **versioned point** (`skill_id@version`) is also written and retained — old versions are kept until explicitly pruned via `make seed-prune` (planned target)
 - Active agent sessions that already loaded a skill body are not affected (the body was copied into context)
-- Future `skills_get_body` calls return the new version
+- Future `skills_get_body` calls return the latest version by default; specific versions can be requested with the `version` parameter or inline `skill_id@version` notation
 
-Skill versioning (pinning to a specific version at query time) is a planned feature. See [docs/VERSIONING.md](docs/VERSIONING.md) for the design.
+Skill versioning is implemented. See [docs/VERSIONING.md](docs/VERSIONING.md) for details including pinning, fallback behavior, and deprecation notices.
 
 ---
 
@@ -148,4 +156,4 @@ See [THREAT_MODEL.md](THREAT_MODEL.md) for the full security model and residual 
 
 ---
 
-*Last reviewed: 2026-05-01*
+*Last reviewed: 2026-05-02*

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,13 +16,16 @@ AI Agent / MCP Client
       │  HTTPS
       ▼
 Cloudflare Worker (Python/Pyodide)
-  ├── Transport: SSE  (GET /sse + POST /messages/)
+  ├── Transport A: SSE  (GET /sse + POST /messages/)     ← Claude Desktop / Claude.ai
+  ├── Transport B: Streamable HTTP  (POST /mcp, stateless) ← Glama / MCP Inspector / new SDKs
+  ├── CORS: Access-Control-Allow-Origin: * on all responses
+  ├── Rate limit: 60 req/min per IP (configurable via RATE_LIMIT_RPM)
   ├── Embedding: Workers AI binding (bge-small-en-v1.5, 384-dim)
   ├── State: Durable Object (in-memory asyncio.Queue per SSE session)
   └── Storage: Qdrant Cloud (read-only at runtime)
 ```
 
-**What works:** all six MCP tools — `skills_find_relevant`, `skills_get_body`, `skills_get_options`, `skills_get_reference`, `skills_run_script` (list mode only), `skills_get_asset`
+**What works:** all six MCP tools — `skills_find_relevant`, `skills_get_body` (with optional `version` parameter), `skills_get_options`, `skills_get_reference`, `skills_run_script` (list mode only), `skills_get_asset`
 
 **What does not work:** `skills_run_script` execution mode — returns a manifest with a note explaining why. The Pyodide runtime does not support `subprocess`.
 
@@ -101,11 +104,17 @@ FastMCP server (Python, skill_mcp/server.py)
 |---------|:-----------------:|:----------:|:-----------:|:------:|
 | `skills_find_relevant` | ✅ | ✅ | ✅ | ✅ |
 | `skills_get_body` | ✅ | ✅ | ✅ | ✅ |
+| `skills_get_body` (version pinning) | ✅ | ✅ | ✅ | ✅ |
 | `skills_get_options` | ✅ | ✅ | ✅ | ✅ |
 | `skills_get_reference` | ✅ | ✅ | ✅ | ✅ |
 | `skills_run_script` (list) | ✅ manifest only | ✅ | ✅ | ✅ |
 | `skills_run_script` (execute) | ❌ Pyodide limit | ✅ | ✅ | ✅ |
 | `skills_get_asset` | ✅ | ✅ | ✅ | ✅ |
+| SSE transport | ✅ | ❌ | ❌ | ❌ |
+| Streamable HTTP transport | ✅ | ✅ | ❌ | ✅ |
+| stdio transport | ❌ | ❌ | ✅ | ❌ |
+| Per-IP rate limiting | ✅ 60 req/min | ❌ | ❌ | ❌ |
+| CORS headers | ✅ | ✅ | n/a | ✅ |
 | Subprocess execution | ❌ | ✅ | ✅ | ✅ |
 | No Qdrant Cloud account | ❌ | ❌ | ❌ | ✅ |
 | No Cloudflare account | ❌ | ✅ | ✅ | ✅* |
@@ -140,10 +149,11 @@ Cloudflare Workers are stateless by default — each request may run in a differ
 
 ### Current
 
-| Deployment | Transport | Status |
-|------------|-----------|--------|
-| Cloudflare Worker | SSE (`GET /sse` + `POST /messages/`) | MCP spec `2024-11-05` — functional, deprecated in favor of streamable-http |
-| Local Python server | `streamable-http` or `stdio` | MCP spec `2024-11-05` — current preferred transports |
+| Deployment | Transport | MCP Spec | Status |
+|------------|-----------|----------|--------|
+| Cloudflare Worker | SSE (`GET /sse` + `POST /messages/`) | `2024-11-05` | Functional — used by Claude Desktop and Claude.ai |
+| Cloudflare Worker | Streamable HTTP (`POST /mcp`, stateless) | `2025-03-26` | Implemented — used by Glama, MCP Inspector, newer SDK clients |
+| Local Python server | `streamable-http` or `stdio` | `2025-03-26` | Current preferred transports |
 
 ### What SSE transport means
 
@@ -154,16 +164,16 @@ The SSE transport works as follows:
 3. Agent sends JSON-RPC requests via `POST /messages/?sessionId=<uuid>` (separate HTTP request)
 4. Worker routes the POST to the matching open SSE session via the DO's `_sessions` dict
 
-This is more complex than `streamable-http` (which uses a single HTTP request-response cycle with streaming response). Migration to `streamable-http` in the Worker would eliminate the DO session routing complexity, but requires Cloudflare Workers to support streaming HTTP responses in Python — check current Cloudflare documentation for status.
+### What Streamable HTTP transport means (Worker)
 
-### Migration path to streamable-http
+The `POST /mcp` endpoint is a stateless JSON-RPC handler:
 
-1. Verify Cloudflare Python Workers support streaming HTTP responses (ASGI response streaming)
-2. Implement `streamable-http` handler in `src/worker.py` alongside existing SSE handler
-3. Test with MCP clients that prefer `streamable-http`
-4. Update `wrangler.jsonc` with any new configuration needed
-5. Update all docs, master-skill files, and README connection snippets
-6. Keep SSE handler alive for a grace period, then remove
+1. Client sends a single JSON-RPC message (e.g., `{"method": "tools/list", ...}`) as the POST body
+2. Worker dispatches the message through the same tool dispatch logic as SSE
+3. Worker returns a single JSON-RPC response directly in the HTTP response body
+4. No session is created — each request is independent
+
+This is simpler than SSE (no session routing, no DO session dict involvement) and required for browser-based testers that cannot establish persistent connections or lack SSE support. CORS preflight (`OPTIONS`) requests return 204 with CORS headers.
 
 ---
 
@@ -208,3 +218,19 @@ This alignment ensures vectors are always comparable: seed-time embeddings and q
 6. Validates file paths with `Path.resolve()` to prevent path traversal
 
 The seed script is run locally by operators, not by the deployed Worker. The Worker is read-only at runtime.
+
+Versioning: the seed script writes two points per skill — a **latest alias** (deterministic ID from `skill_id`) and a **versioned point** (ID from `skill_id@version`). The latest alias is always overwritten; versioned points accumulate until pruned. See [VERSIONING.md](VERSIONING.md).
+
+---
+
+## Threshold Calibration
+
+`skill_mcp/eval/calibrate.py` is a standalone calibration runner. It:
+
+1. Loads `tests/eval/threshold_calibration.json` (120 eval triples — 90 strong-match + 30 true-negative)
+2. Calls `skills_find_relevant` for each query
+3. Sweeps `(t_high, t_low)` pairs in the range `[0.50–0.70] × [0.30–0.45]`
+4. Reports precision, recall, F1, and specificity for each pair
+5. Exits 0 if any pair meets the targets (precision ≥ 0.90, recall ≥ 0.85), exits 1 if not
+
+Run with `make calibrate`. Requires live Qdrant access and a seeded registry. See [THRESHOLD_CALIBRATION.md](THRESHOLD_CALIBRATION.md) for full documentation.

--- a/docs/THRESHOLD_CALIBRATION.md
+++ b/docs/THRESHOLD_CALIBRATION.md
@@ -1,7 +1,7 @@
 # Threshold Calibration Framework
 
-**Status:** Framework defined — evaluation dataset not yet built  
-**Relevant code:** `skill_mcp/tools/find_skills.py`, `src/worker.py` (`_skills_find_relevant`)
+**Status:** Implemented — dataset and calibration runner both exist  
+**Relevant code:** `skill_mcp/tools/find_skills.py`, `src/worker.py` (`_skills_find_relevant`), `skill_mcp/eval/calibrate.py`, `tests/eval/threshold_calibration.json`
 
 ---
 
@@ -194,25 +194,32 @@ The evaluation dataset should live at `tests/eval/threshold_calibration.json`. I
 python -m skill_mcp.eval.calibrate --dataset tests/eval/threshold_calibration.json
 ```
 
-The `skill_mcp/eval/` module does not yet exist. This is a TODO.
+Run calibration with:
+
+```bash
+make calibrate
+# or:
+python -m skill_mcp.eval.calibrate --dataset tests/eval/threshold_calibration.json
+# CI mode (exit 0 = targets met):
+python -m skill_mcp.eval.calibrate --quiet
+```
+
+Exit codes: `0` = at least one pair meets precision ≥ 0.90 and recall ≥ 0.85 · `1` = no pair meets targets · `2` = setup error.
 
 ---
 
-## TODOs (Implementation)
+## Implementation Status
 
-- [ ] Create `tests/eval/threshold_calibration.json` with at least 120 (query, skill, relevance) triples
-- [ ] Create `skill_mcp/eval/__init__.py` + `skill_mcp/eval/calibrate.py` implementing the sweep
-- [ ] Add `make calibrate` target to `Makefile`
-- [ ] Update master-skill files to note that thresholds are calibrated against this dataset (once calibration is complete)
-- [ ] Run calibration after every significant skill addition (>5 new skills) and document results in this file
+- ✅ `tests/eval/threshold_calibration.json`: 120 triples — 90 strong-match (3 per skill × 30 skills) + 30 true negatives
+- ✅ `skill_mcp/eval/__init__.py` + `skill_mcp/eval/calibrate.py`: full sweep with precision/recall/F1/specificity table, `--quiet` CI mode, exit codes 0/1/2
+- ✅ `make calibrate` target added to `Makefile`
+- ⏳ Run calibration after first full seeded deployment and record results here
+- ⏳ Update master-skill files with calibrated threshold values once sweep results are known
 
 ---
 
-## Current Status
+## Current Threshold Status
 
-Thresholds `T_high = 0.6` and `T_low = 0.4` are the current values. They are used in:
-- All `master-skill/platforms/*/` files
-- Tool descriptions in `src/worker.py` and `skill_mcp/server.py`
-- `README.md`
+Thresholds `T_high = 0.6` and `T_low = 0.4` remain judgment-based starting points — the calibration sweep has not yet been run against a fully seeded registry. Run `make calibrate` after seeding and record the best-pair output here.
 
-**These values should not change until the evaluation dataset exists.** Changing them without measurement could regress agent behavior in both directions. They represent a reasonable starting point, not a calibrated optimum.
+**Do not change these values without running the sweep.** A threshold change that looks right on intuition can shift agent behavior in both directions across the 30-skill corpus.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,7 +1,7 @@
 # Skill Versioning Design
 
-**Status:** Design proposal — not yet implemented  
-**Affects:** `skill_mcp/models/skill.py`, `skill_mcp/db/qdrant_manager.py`, `skill_mcp/seed/seed_skills.py`, `src/worker.py`
+**Status:** Implemented  
+**Implemented in:** `skill_mcp/models/skill.py`, `skill_mcp/db/qdrant_manager.py`, `skill_mcp/seed/seed_skills.py`, `skill_mcp/tools/get_skill_body.py`, `skill_mcp/server.py`, `src/worker.py`
 
 ---
 
@@ -161,12 +161,12 @@ Phases A and B can land independently. Phase C requires both worker and local se
 
 ---
 
-## TODOs (Implementation)
+## Implementation Status
 
-- [ ] `skill_mcp/seed/seed_skills.py`: update `_skill_uuid()` to accept version suffix; add `latest` alias upsert
-- [ ] `skill_mcp/db/qdrant_manager.py`: add `get_skill_body_versioned(skill_id, version)` method
-- [ ] `skill_mcp/tools/get_skill_body.py`: parse `version` parameter; call versioned getter
-- [ ] `src/worker.py`: same changes as tools/get_skill_body.py for Worker deployment
-- [ ] `skill_mcp/models/skill.py`: add `deprecated: bool` and `replaced_by: str` fields to `SkillFrontMatter`
-- [ ] CI: add version format validation to `validate-skills` workflow
-- [ ] `Makefile`: add `seed-prune` target
+- ✅ `skill_mcp/models/skill.py`: `deprecated: bool` and `replaced_by: str` added to `SkillFrontMatter` and `SkillRecord`
+- ✅ `skill_mcp/db/qdrant_manager.py`: `get_body_versioned(skill_id, version)` and `get_frontmatter_payload(skill_id)` methods; `version_key` keyword index on body collection; `upsert_many_frontmatter` / `upsert_many_body` write both latest alias and versioned points
+- ✅ `skill_mcp/tools/get_skill_body.py`: accepts `version` parameter and inline `@version` suffix; falls back to latest with `version_note`; attaches `deprecation_notice` when deprecated
+- ✅ `skill_mcp/server.py`: tool registration passes `version=version`
+- ✅ `src/worker.py`: identical version pinning, inline suffix, and deprecation notice in the Worker
+- ⏳ CI: version format validation in `validate-skills` workflow (not yet added)
+- ⏳ `Makefile`: `seed-prune` target for removing old version points (not yet added)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,17 +5,19 @@
 # its deps (mcp>=1.5.0) are declared in pyproject.toml and
 # bundled automatically by wrangler on deploy.
 
-qdrant-client>=1.9.0
-pydantic>=2.0.0
-python-frontmatter>=1.1.0
-PyYAML>=6.0.0
-python-dotenv>=1.0.0
-requests>=2.31.0
+qdrant-client==1.17.1
+pydantic==2.12.5
+python-frontmatter==1.1.0
+PyYAML==6.0.3
+python-dotenv==1.2.2
+requests==2.32.5
 
 # ── Optional: run the Python FastMCP server locally (for script execution) ────
-# pip install fastmcp>=2.0.0 uvicorn>=0.29.0
+# pip install -r requirements-server.txt
 # then: MCP_TRANSPORT=streamable-http python -m skill_mcp.server
+fastmcp==3.2.4
+uvicorn==0.45.0
 
 # ── Dev / testing ─────────────────────────────────────────────────────────────
-pytest>=8.0.0
-pytest-asyncio>=0.23.0
+pytest==9.0.3
+pytest-asyncio==1.3.0

--- a/skill_mcp/db/qdrant_manager.py
+++ b/skill_mcp/db/qdrant_manager.py
@@ -108,6 +108,16 @@ class QdrantManager:
                     field_schema=PayloadSchemaType.KEYWORD,
                 )
 
+        # Ensure version_key index exists on body collection (idempotent — safe to run on existing collections)
+        try:
+            self.client.create_payload_index(
+                collection_name=BODY_COLLECTION,
+                field_name="version_key",
+                field_schema=PayloadSchemaType.KEYWORD,
+            )
+        except Exception:
+            pass  # Already exists — ignore
+
         # ── Tier-3: references, scripts, assets (payload-only, skill_id+filename lookup) ──
 
         for col in (REFERENCES_COLLECTION, SCRIPTS_COLLECTION, ASSETS_COLLECTION):
@@ -159,25 +169,47 @@ class QdrantManager:
     def upsert_many_frontmatter(
         self, pairs: list[tuple[SkillFrontMatter, list[float]]]
     ) -> None:
-        points = [
-            PointStruct(
+        points = []
+        for fm, vec in pairs:
+            payload = fm.model_dump(exclude={"score"})
+            # Latest alias point — always overwritten by re-seeding
+            points.append(PointStruct(
                 id=_skill_uuid(fm.skill_id),
                 vector=vec,
-                payload=fm.model_dump(exclude={"score"}),
-            )
-            for fm, vec in pairs
-        ]
+                payload=payload,
+            ))
+            # Versioned point — kept alongside the latest alias
+            if fm.version:
+                ver_key = f"{fm.skill_id}@{fm.version}"
+                points.append(PointStruct(
+                    id=_skill_uuid(ver_key),
+                    vector=vec,
+                    payload={**payload, "version_key": ver_key},
+                ))
         self.client.upsert(collection_name=FRONTMATTER_COLLECTION, points=points)
 
-    def upsert_many_body(self, bodies: list[SkillBody]) -> None:
-        points = [
-            PointStruct(
+    def upsert_many_body(
+        self, bodies: list[SkillBody], versions: list[str] | None = None
+    ) -> None:
+        """Upsert body payloads. If *versions* is provided (same length as *bodies*),
+        also writes a versioned point keyed by 'skill_id@version'."""
+        points = []
+        for i, b in enumerate(bodies):
+            payload = b.model_dump()
+            # Latest alias
+            points.append(PointStruct(
                 id=_skill_uuid(f"body:{b.skill_id}"),
                 vector=_DUMMY_VEC,
-                payload=b.model_dump(),
-            )
-            for b in bodies
-        ]
+                payload=payload,
+            ))
+            # Versioned point
+            if versions and i < len(versions) and versions[i]:
+                ver_key = f"{b.skill_id}@{versions[i]}"
+                points.append(PointStruct(
+                    id=_skill_uuid(f"body:{ver_key}"),
+                    vector=_DUMMY_VEC,
+                    payload={**payload, "version_key": ver_key},
+                ))
         self.client.upsert(collection_name=BODY_COLLECTION, points=points)
 
     def upsert_many_options(self, options_list: list[SkillOptions]) -> None:
@@ -260,7 +292,30 @@ class QdrantManager:
 
     def get_body(self, skill_id: str) -> Optional[SkillBody]:
         payload = self._payload_lookup(BODY_COLLECTION, skill_id)
-        return SkillBody(**payload) if payload else None
+        if payload is None:
+            return None
+        # Filter to only known SkillBody fields — extra keys (e.g. version_key) cause Pydantic errors
+        return SkillBody(**{k: v for k, v in payload.items() if k in SkillBody.model_fields})
+
+    def get_body_versioned(self, skill_id: str, version: str) -> Optional[SkillBody]:
+        """Fetch a specific pinned version of a skill body by 'skill_id@version' key."""
+        ver_key = f"{skill_id}@{version}"
+        points, _ = self.client.scroll(
+            collection_name=BODY_COLLECTION,
+            scroll_filter=Filter(
+                must=[FieldCondition(key="version_key", match=MatchValue(value=ver_key))]
+            ),
+            with_payload=True,
+            limit=1,
+        )
+        if not points or not points[0].payload:
+            return None
+        payload = points[0].payload
+        return SkillBody(**{k: v for k, v in payload.items() if k in SkillBody.model_fields})
+
+    def get_frontmatter_payload(self, skill_id: str) -> Optional[dict]:
+        """Return raw frontmatter payload dict for a skill (for deprecation checks)."""
+        return self._payload_lookup(FRONTMATTER_COLLECTION, skill_id)
 
     def get_options(self, skill_id: str) -> Optional[SkillOptions]:
         payload = self._payload_lookup(OPTIONS_COLLECTION, skill_id)

--- a/skill_mcp/eval/__init__.py
+++ b/skill_mcp/eval/__init__.py
@@ -1,0 +1,1 @@
+# skill_mcp.eval — threshold calibration tools

--- a/skill_mcp/eval/calibrate.py
+++ b/skill_mcp/eval/calibrate.py
@@ -1,0 +1,255 @@
+"""
+Threshold calibration sweep for skills_find_relevant.
+
+Runs each query in the eval dataset through find_relevant_skills(), then sweeps
+over (t_high, t_low) pairs and computes precision, recall, F1, and specificity.
+
+Usage:
+    python -m skill_mcp.eval.calibrate
+    python -m skill_mcp.eval.calibrate --dataset tests/eval/threshold_calibration.json
+    python -m skill_mcp.eval.calibrate --top-k 5 --top 10
+    python -m skill_mcp.eval.calibrate --quiet          # one-line best-pair summary only
+
+Exit codes:
+    0  Best pair meets precision >= 0.90 AND recall >= 0.85
+    1  No pair meets target thresholds
+    2  Setup / IO error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DEFAULT_DATASET = _REPO_ROOT / "tests" / "eval" / "threshold_calibration.json"
+
+# Sweep ranges
+_T_HIGH_CANDIDATES = [0.50, 0.55, 0.60, 0.65, 0.70]
+_T_LOW_CANDIDATES  = [0.30, 0.35, 0.40, 0.45]
+
+# Pass/fail targets
+_TARGET_PRECISION = 0.90
+_TARGET_RECALL    = 0.85
+
+
+# ── Data structures ───────────────────────────────────────────────────────────
+
+@dataclass
+class EvalTriple:
+    query: str
+    expected_skill_id: Optional[str]  # None → negative example
+    relevance: str                     # "strong" | "none"
+
+
+@dataclass
+class SearchHit:
+    skill_id: str
+    score: float
+
+
+@dataclass
+class ThresholdResult:
+    t_high: float
+    t_low: float
+    tp: int   # positive query → expected skill found with score >= t_high
+    fn: int   # positive query → expected skill not found at t_high
+    tn: int   # negative query → top score < t_low
+    fp: int   # negative query → top score >= t_low
+
+    @property
+    def precision(self) -> float:
+        denom = self.tp + self.fp
+        return self.tp / denom if denom else 0.0
+
+    @property
+    def recall(self) -> float:
+        denom = self.tp + self.fn
+        return self.tp / denom if denom else 0.0
+
+    @property
+    def f1(self) -> float:
+        p, r = self.precision, self.recall
+        return 2 * p * r / (p + r) if (p + r) else 0.0
+
+    @property
+    def specificity(self) -> float:
+        denom = self.tn + self.fp
+        return self.tn / denom if denom else 0.0
+
+    def meets_target(self) -> bool:
+        return self.precision >= _TARGET_PRECISION and self.recall >= _TARGET_RECALL
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _load_dataset(path: Path) -> list[EvalTriple]:
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    return [
+        EvalTriple(
+            query=item["query"],
+            expected_skill_id=item.get("expected_skill_id"),
+            relevance=item.get("relevance", "none"),
+        )
+        for item in raw
+    ]
+
+
+def _run_queries(
+    triples: list[EvalTriple],
+    top_k: int,
+    quiet: bool,
+) -> dict[str, list[SearchHit]]:
+    """Run every unique query and return results keyed by query string."""
+    from ..tools.find_skills import find_relevant_skills
+
+    results: dict[str, list[SearchHit]] = {}
+    unique = list({t.query for t in triples})
+
+    for i, query in enumerate(unique, 1):
+        if not quiet:
+            print(f"  [{i:3d}/{len(unique)}] {query[:70]}", end="\r", flush=True)
+        raw = find_relevant_skills(query=query, top_k=top_k)
+        data = json.loads(raw)
+        hits = [
+            SearchHit(skill_id=r["skill_id"], score=r.get("score") or 0.0)
+            for r in data.get("results", [])
+        ]
+        results[query] = hits
+        time.sleep(0.05)  # polite pause between queries
+
+    if not quiet:
+        print(" " * 90, end="\r")  # clear progress line
+
+    return results
+
+
+def _sweep(
+    triples: list[EvalTriple],
+    query_results: dict[str, list[SearchHit]],
+) -> list[ThresholdResult]:
+    rows: list[ThresholdResult] = []
+    for t_high in _T_HIGH_CANDIDATES:
+        for t_low in _T_LOW_CANDIDATES:
+            if t_low >= t_high:
+                continue
+            tp = fn = tn = fp = 0
+            for triple in triples:
+                hits = query_results.get(triple.query, [])
+                if triple.relevance == "strong" and triple.expected_skill_id:
+                    top_expected = next(
+                        (h for h in hits if h.skill_id == triple.expected_skill_id), None
+                    )
+                    if top_expected and top_expected.score >= t_high:
+                        tp += 1
+                    else:
+                        fn += 1
+                elif triple.relevance == "none":
+                    top_score = hits[0].score if hits else 0.0
+                    if top_score < t_low:
+                        tn += 1
+                    else:
+                        fp += 1
+            rows.append(ThresholdResult(t_high=t_high, t_low=t_low, tp=tp, fn=fn, tn=tn, fp=fp))
+
+    rows.sort(key=lambda r: (r.f1, r.precision, r.recall), reverse=True)
+    return rows
+
+
+def _print_table(rows: list[ThresholdResult], top: int) -> None:
+    header = (
+        f"{'t_high':>7}  {'t_low':>6}  "
+        f"{'prec':>6}  {'recall':>7}  {'F1':>6}  {'spec':>6}  "
+        f"{'TP':>4}  {'FN':>4}  {'TN':>4}  {'FP':>4}  {'OK':>3}"
+    )
+    print()
+    print(header)
+    print("─" * len(header))
+    for r in rows[:top]:
+        ok = "✓" if r.meets_target() else " "
+        print(
+            f"{r.t_high:7.2f}  {r.t_low:6.2f}  "
+            f"{r.precision:6.3f}  {r.recall:7.3f}  {r.f1:6.3f}  {r.specificity:6.3f}  "
+            f"{r.tp:4d}  {r.fn:4d}  {r.tn:4d}  {r.fp:4d}  {ok:>3}"
+        )
+    print()
+
+
+def _best(rows: list[ThresholdResult]) -> Optional[ThresholdResult]:
+    return next((r for r in rows if r.meets_target()), None)
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--dataset", default=str(_DEFAULT_DATASET), help="Path to eval dataset JSON")
+    parser.add_argument("--top-k", type=int, default=5, help="top_k for find_relevant_skills (default 5)")
+    parser.add_argument("--top", type=int, default=15, help="Rows to print in table (default 15)")
+    parser.add_argument("--quiet", action="store_true", help="Print only best-pair line (CI mode)")
+    args = parser.parse_args(argv)
+
+    dataset_path = Path(args.dataset)
+    if not dataset_path.exists():
+        print(f"[calibrate] Dataset not found: {dataset_path}", file=sys.stderr)
+        return 2
+
+    if not args.quiet:
+        print(f"[calibrate] Dataset:  {dataset_path}")
+        print(f"[calibrate] top_k:    {args.top_k}")
+        print(f"[calibrate] Targets:  precision >= {_TARGET_PRECISION:.0%}, recall >= {_TARGET_RECALL:.0%}")
+        print()
+
+    try:
+        triples = _load_dataset(dataset_path)
+    except Exception as exc:
+        print(f"[calibrate] Failed to load dataset: {exc}", file=sys.stderr)
+        return 2
+
+    pos = sum(1 for t in triples if t.relevance == "strong")
+    neg = sum(1 for t in triples if t.relevance == "none")
+    if not args.quiet:
+        print(f"[calibrate] Loaded {len(triples)} triples: {pos} positive, {neg} negative")
+        print(f"[calibrate] Running {len({t.query for t in triples})} unique queries …")
+
+    try:
+        query_results = _run_queries(triples, top_k=args.top_k, quiet=args.quiet)
+    except Exception as exc:
+        print(f"[calibrate] Query execution failed: {exc}", file=sys.stderr)
+        return 2
+
+    rows = _sweep(triples, query_results)
+
+    if not args.quiet:
+        _print_table(rows, top=args.top)
+
+    best = _best(rows)
+    if best:
+        print(
+            f"[calibrate] BEST  t_high={best.t_high:.2f}  t_low={best.t_low:.2f}  "
+            f"precision={best.precision:.3f}  recall={best.recall:.3f}  F1={best.f1:.3f}"
+        )
+        return 0
+    else:
+        best_f1 = rows[0] if rows else None
+        if best_f1 and not args.quiet:
+            print(
+                f"[calibrate] WARN  No pair meets targets "
+                f"(precision >= {_TARGET_PRECISION:.0%}, recall >= {_TARGET_RECALL:.0%}). "
+                f"Best F1={best_f1.f1:.3f} at t_high={best_f1.t_high:.2f}/t_low={best_f1.t_low:.2f}."
+            )
+        else:
+            print("[calibrate] FAIL  No threshold pair meets precision/recall targets.")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skill_mcp/models/skill.py
+++ b/skill_mcp/models/skill.py
@@ -25,6 +25,9 @@ class SkillFrontMatter(BaseModel):
     # skill:// URI for MCP SkillsProvider compatibility
     skill_uri: str = ""
     score: Optional[float] = None  # populated after vector search
+    # Deprecation — set in SKILL.md frontmatter when a skill is superseded
+    deprecated: bool = False
+    replaced_by: str = ""  # skill_id of the replacement, or "" if none
 
 
 # ── Tier-2: Body + Options ────────────────────────────────────────────────────
@@ -124,6 +127,8 @@ class SkillRecord(BaseModel):
     variants: list[dict[str, Any]] = Field(default_factory=list)
     dependencies: list[str] = Field(default_factory=list)
     limitations: list[str] = Field(default_factory=list)
+    deprecated: bool = False
+    replaced_by: str = ""
 
     def to_frontmatter(self) -> SkillFrontMatter:
         return SkillFrontMatter(
@@ -137,6 +142,8 @@ class SkillRecord(BaseModel):
             author=self.author,
             license=self.license,
             skill_uri=f"skill://{self.skill_id}/SKILL.md",
+            deprecated=self.deprecated,
+            replaced_by=self.replaced_by,
         )
 
     def to_body(self) -> SkillBody:

--- a/skill_mcp/server.py
+++ b/skill_mcp/server.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import os
 from contextlib import asynccontextmanager
-from typing import AsyncIterator
+from typing import AsyncIterator, Optional
 
 from dotenv import load_dotenv
 from fastmcp import FastMCP
@@ -111,11 +111,15 @@ def _skills_find_relevant(query: str, top_k: int = 5) -> str:
         "After loading: apply the instructions. "
         "If tier3_manifest lists files that the instructions explicitly reference, "
         "fetch them with skills_get_reference, skills_run_script, or skills_get_asset. "
-        "Most tasks are fully served by the instructions alone — do not load Tier 3 speculatively."
+        "Most tasks are fully served by the instructions alone — do not load Tier 3 speculatively.\n\n"
+        "Version pinning: pass version='1.2' to pin to a specific skill version, or use the "
+        "inline form skill_id='stripe-integration@1.2'. If the requested version is not found, "
+        "the latest version is returned with a version_note explaining the fallback. "
+        "Deprecated skills include a deprecation_notice field naming the replacement."
     ),
 )
-def _skills_get_body(skill_id: str) -> str:
-    return get_skill_body(skill_id=skill_id)
+def _skills_get_body(skill_id: str, version: Optional[str] = None) -> str:
+    return get_skill_body(skill_id=skill_id, version=version)
 
 
 @mcp.tool(

--- a/skill_mcp/tools/get_skill_body.py
+++ b/skill_mcp/tools/get_skill_body.py
@@ -4,12 +4,17 @@ The response includes a tier3_manifest field listing available reference files,
 scripts, and assets by filename only — no content is loaded. This lets the
 agent selectively fetch only what the instructions reference (progressive
 disclosure). If no tier-3 files exist for a skill the manifest is empty.
+
+Version pinning: pass version="1.2" to pin to a specific skill version.
+If the requested version is not found the latest version is returned with a
+version_note field explaining the fallback.
 """
 
 from __future__ import annotations
 
 import json
 import os
+from typing import Optional
 
 from ..db.cache import TTLCache
 from ..db.qdrant_manager import qdrant_manager
@@ -20,7 +25,7 @@ _body_cache: TTLCache = TTLCache(
 )
 
 
-def get_skill_body(skill_id: str) -> str:
+def get_skill_body(skill_id: str, version: Optional[str] = None) -> str:
     """Retrieve the full body (instructions + system prompt addition) for a skill.
 
     Call this after skills_find_relevant once you have decided which skill to
@@ -35,17 +40,42 @@ def get_skill_body(skill_id: str) -> str:
 
     Args:
         skill_id: The skill_id string returned by skills_find_relevant.
+                  May include an inline version suffix: "stripe-integration@1.2"
+        version:  Optional version string (e.g. "1.2"). If provided and found,
+                  the pinned version body is returned. If not found, the latest
+                  version is returned with a version_note field.
 
     Returns:
         JSON string matching the SkillBody schema plus tier3_manifest field,
         or an error object if the skill_id is not found.
     """
-    cache_key = f"body|{skill_id}"
+    # Parse inline version suffix: "stripe-integration@1.2"
+    if "@" in skill_id and version is None:
+        skill_id, version = skill_id.rsplit("@", 1)
+
+    cache_key = f"body|{skill_id}|{version or 'latest'}"
     cached = _body_cache.get(cache_key)
     if cached is not None:
         return cached
 
-    body = qdrant_manager.get_body(skill_id)
+    version_note: Optional[str] = None
+    actual_version: Optional[str] = None
+
+    if version:
+        body = qdrant_manager.get_body_versioned(skill_id, version)
+        if body is None:
+            # Requested version not found — fall back to latest
+            body = qdrant_manager.get_body(skill_id)
+            if body is not None:
+                version_note = (
+                    f"Requested version {version!r} not found in registry; "
+                    f"returning latest version."
+                )
+        else:
+            actual_version = version
+    else:
+        body = qdrant_manager.get_body(skill_id)
+
     if body is None:
         return json.dumps(
             {"error": f"skill_id '{skill_id}' not found in body collection"}
@@ -53,6 +83,23 @@ def get_skill_body(skill_id: str) -> str:
 
     body_dict = body.model_dump()
     body_dict["tier3_manifest"] = qdrant_manager.get_tier3_manifest(skill_id)
+
+    if version_note:
+        body_dict["version_note"] = version_note
+    if actual_version:
+        body_dict["pinned_version"] = actual_version
+
+    # Attach deprecation notice if the skill is marked deprecated in frontmatter.
+    try:
+        fm_payload = qdrant_manager.get_frontmatter_payload(skill_id)
+        if fm_payload and fm_payload.get("deprecated"):
+            replaced_by = fm_payload.get("replaced_by", "")
+            msg = "This skill is deprecated."
+            if replaced_by:
+                msg += f" Use '{replaced_by}' instead."
+            body_dict["deprecation_notice"] = msg
+    except Exception:
+        pass
 
     result = json.dumps(body_dict, indent=2)
     _body_cache.set(cache_key, result)

--- a/src/worker.py
+++ b/src/worker.py
@@ -1,18 +1,26 @@
 """
 Cloudflare Workers entry point for skill-mcp.
 
-MCP SSE protocol implemented as a bare ASGI callable — zero third-party
-dependencies, works in Cloudflare's Pyodide runtime without a requirements.txt.
+Two MCP transports — both active simultaneously:
 
-Transport: SSE (MCP spec 2024-11-05)
-  GET  /sse          — open SSE stream; server sends messages endpoint URL
-  POST /messages/    — receive JSON-RPC message; response sent via SSE stream
+  Legacy SSE (MCP spec 2024-11-05) — Claude Desktop, Claude.ai, Cursor, etc.
+    GET  /sse          — open SSE stream; server sends messages endpoint URL
+    POST /messages/    — receive JSON-RPC message; response sent via SSE stream
+
+  Streamable HTTP (MCP spec 2025-03-26) — Glama, new SDK clients
+    POST /mcp          — stateless JSON-RPC request→response
+    OPTIONS *          — CORS preflight (204 + CORS headers)
+
+CORS headers are included on every response so browser-based testers work.
 
 Bindings (wrangler.jsonc + `wrangler secret put`):
   AI             — Workers AI (@cf/baai/bge-small-en-v1.5, 384-dim)
   QDRANT_URL     — secret: Qdrant Cloud cluster URL
   QDRANT_API_KEY — secret: Qdrant Cloud API key
   MCP_OBJECT     — Durable Object (holds ASGI app + SSE session state)
+
+Optional env vars:
+  RATE_LIMIT_RPM — per-IP rate limit in requests/min (default: 60)
 """
 
 from __future__ import annotations
@@ -20,6 +28,7 @@ from __future__ import annotations
 import asyncio
 import js  # Pyodide JS bridge — always available in Cloudflare Python Workers
 import json
+import time
 import urllib.parse
 import uuid
 from typing import Any
@@ -121,6 +130,11 @@ def _by_skill_file(skill_id: str, filename: str) -> dict:
     }
 
 
+def _by_version_key(version_key: str) -> dict:
+    """Filter for a specific versioned body point, e.g. 'stripe-integration@1.2'."""
+    return {"must": [{"key": "version_key", "match": {"value": version_key}}]}
+
+
 # ── MCP tool schemas (returned by tools/list) ─────────────────────────────────
 
 _MCP_TOOLS: list[dict] = [
@@ -169,14 +183,25 @@ _MCP_TOOLS: list[dict] = [
             "After loading: apply the instructions. "
             "If tier3_manifest lists files that the instructions explicitly reference, "
             "fetch them with skills_get_reference, skills_run_script, or skills_get_asset. "
-            "Most tasks are fully served by the instructions alone — do not load Tier 3 speculatively."
+            "Most tasks are fully served by the instructions alone — do not load Tier 3 speculatively.\n\n"
+            "Version pinning: pass version='1.2' to pin to a specific skill version, or use the "
+            "inline form skill_id='stripe-integration@1.2'. If the requested version is not found, "
+            "the latest version is returned with a version_note explaining the fallback. "
+            "Deprecated skills include a deprecation_notice field naming the replacement."
         ),
         "inputSchema": {
             "type": "object",
             "properties": {
                 "skill_id": {
                     "type": "string",
-                    "description": "skill_id from the top-scoring skills_find_relevant result",
+                    "description": (
+                        "skill_id from skills_find_relevant. "
+                        "May include an inline version suffix: 'stripe-integration@1.2'"
+                    ),
+                },
+                "version": {
+                    "type": "string",
+                    "description": "Optional version string (e.g. '1.2') to pin to a specific skill version.",
                 },
             },
             "required": ["skill_id"],
@@ -296,17 +321,49 @@ _MCP_TOOLS: list[dict] = [
 
 def _build_server(env: Any):
     """
-    Return a bare ASGI callable implementing the MCP SSE transport.
+    Return a bare ASGI callable implementing both MCP transports.
     No third-party packages required — pure stdlib.
 
     Routes:
-      GET  /sse        — open SSE stream, send endpoint event
-      POST /messages/  — receive JSON-RPC, put response on SSE queue
+      OPTIONS *        — CORS preflight (204)
+      GET  /sse        — legacy SSE transport: open stream, send endpoint event
+      POST /messages/  — legacy SSE transport: receive JSON-RPC, route to stream
+      POST /mcp        — Streamable HTTP: stateless JSON-RPC request→response
     """
 
     # Active SSE sessions: session_id → asyncio.Queue of outbound JSON-RPC dicts.
     # Lives in this closure, which is held by the DO instance.
     _sessions: dict[str, asyncio.Queue] = {}
+
+    # ── Per-IP rate limiting ───────────────────────────────────────────────────
+    _RATE_LIMIT: int = int(getattr(env, "RATE_LIMIT_RPM", None) or 60)
+    _RATE_WINDOW: float = 60.0
+    _rate_store: dict[str, list[float]] = {}
+
+    def _check_rate_limit(ip: str) -> bool:
+        now = time.time()
+        cutoff = now - _RATE_WINDOW
+        timestamps = _rate_store.get(ip, [])
+        timestamps = [t for t in timestamps if t > cutoff]
+        if len(timestamps) >= _RATE_LIMIT:
+            _rate_store[ip] = timestamps
+            return False
+        timestamps.append(now)
+        _rate_store[ip] = timestamps
+        # Evict stale IPs when store grows beyond 10k entries
+        if len(_rate_store) > 10_000:
+            stale_cutoff = now - _RATE_WINDOW * 2
+            stale = [k for k, v in _rate_store.items() if not v or max(v) < stale_cutoff]
+            for k in stale:
+                del _rate_store[k]
+        return True
+
+    def _client_ip(scope: dict) -> str:
+        headers = dict(scope.get("headers", []))
+        return (
+            headers.get(b"cf-connecting-ip", b"").decode()
+            or headers.get(b"x-forwarded-for", b"unknown").decode().split(",")[0].strip()
+        )
 
     C_FM = "skill_frontmatter"
     C_BODY = "skill_body"
@@ -419,14 +476,48 @@ def _build_server(env: Any):
             {"query": query, "total_found": len(skills), "results": skills}, indent=2
         )
 
-    async def _skills_get_body(skill_id: str) -> str:
+    async def _skills_get_body(skill_id: str, version: str | None = None) -> str:
         QU, QK = _creds()
-        payloads = await _scroll(QU, QK, C_BODY, _by_skill(skill_id), 1)
+
+        # Parse inline version suffix: "stripe-integration@1.2"
+        if "@" in skill_id and version is None:
+            skill_id, version = skill_id.rsplit("@", 1)
+
+        version_note: str | None = None
+
+        if version:
+            # Try pinned version point first
+            ver_key = f"{skill_id}@{version}"
+            payloads = await _scroll(QU, QK, C_BODY, _by_version_key(ver_key), 1)
+            if not payloads:
+                # Fall back to latest with a note
+                payloads = await _scroll(QU, QK, C_BODY, _by_skill(skill_id), 1)
+                if payloads:
+                    version_note = (
+                        f"Requested version {version!r} not found in registry; "
+                        f"returning latest version."
+                    )
+        else:
+            payloads = await _scroll(QU, QK, C_BODY, _by_skill(skill_id), 1)
+
         if not payloads:
             return json.dumps(
                 {"error": f"skill_id '{skill_id}' not found in body collection"}
             )
         body = payloads[0]
+
+        # Attach version_note if version was requested but not found
+        if version_note:
+            body = {**body, "version_note": version_note}
+
+        # Attach deprecation notice from frontmatter if deprecated
+        fm_payloads = await _scroll(QU, QK, C_FM, _by_skill(skill_id), 1)
+        if fm_payloads and fm_payloads[0].get("deprecated"):
+            replaced_by = fm_payloads[0].get("replaced_by", "")
+            msg = "This skill is deprecated."
+            if replaced_by:
+                msg += f" Use '{replaced_by}' instead."
+            body = {**body, "deprecation_notice": msg}
         refs = sorted(
             p.get("filename", "")
             for p in await _scroll(QU, QK, C_REFS, _by_skill(skill_id))
@@ -646,7 +737,10 @@ def _build_server(env: Any):
                 top_k=top_k,
             )
         elif name == "skills_get_body":
-            return await _skills_get_body(skill_id=str(args.get("skill_id", "")))
+            return await _skills_get_body(
+                skill_id=str(args.get("skill_id", "")),
+                version=args.get("version") or None,
+            )
         elif name == "skills_get_options":
             return await _skills_get_options(skill_id=str(args.get("skill_id", "")))
         elif name == "skills_get_reference":
@@ -748,12 +842,20 @@ def _build_server(env: Any):
 
     # ── Bare ASGI helpers ──────────────────────────────────────────────────────
 
-    # Security headers added to every non-SSE HTTP response
+    # Security headers added to every HTTP response
     _SECURITY_HEADERS: list[tuple[bytes, bytes]] = [
         (b"x-content-type-options", b"nosniff"),
         (b"x-frame-options", b"DENY"),
         (b"cache-control", b"no-store"),
         (b"referrer-policy", b"no-referrer"),
+    ]
+
+    # CORS headers — required for browser-based MCP testers (Glama, etc.)
+    _CORS_HEADERS: list[tuple[bytes, bytes]] = [
+        (b"access-control-allow-origin", b"*"),
+        (b"access-control-allow-methods", b"GET, POST, OPTIONS"),
+        (b"access-control-allow-headers", b"content-type, authorization, mcp-session-id, last-event-id"),
+        (b"access-control-max-age", b"86400"),
     ]
 
     async def _send_response(
@@ -763,7 +865,11 @@ def _build_server(env: Any):
         content_type: bytes = b"application/json",
         extra_headers: list | None = None,
     ) -> None:
-        headers = [(b"content-type", content_type), *_SECURITY_HEADERS]
+        headers = [
+            (b"content-type", content_type),
+            *_SECURITY_HEADERS,
+            *_CORS_HEADERS,
+        ]
         if extra_headers:
             headers.extend(extra_headers)
         await send({"type": "http.response.start", "status": status, "headers": headers})
@@ -799,6 +905,13 @@ def _build_server(env: Any):
 
     async def _handle_sse(scope: dict, receive: Any, send: Any) -> None:
         """GET /sse — open SSE stream, send endpoint event, relay responses."""
+        # Rate limit
+        ip = _client_ip(scope)
+        if not _check_rate_limit(ip):
+            body = json.dumps({"error": "Too Many Requests"}).encode()
+            await _send_response(send, 429, body)
+            return
+
         session_id = str(uuid.uuid4())
         queue: asyncio.Queue = asyncio.Queue()
         _sessions[session_id] = queue
@@ -815,6 +928,8 @@ def _build_server(env: Any):
                     (b"cache-control", b"no-cache"),
                     (b"connection", b"keep-alive"),
                     (b"x-accel-buffering", b"no"),
+                    # CORS — needed for browser clients
+                    *_CORS_HEADERS,
                 ],
             }
         )
@@ -836,8 +951,49 @@ def _build_server(env: Any):
 
         await send({"type": "http.response.body", "body": b"", "more_body": False})
 
+    async def _handle_mcp_post(scope: dict, receive: Any, send: Any) -> None:
+        """POST /mcp — stateless Streamable HTTP transport (MCP spec 2025-03-26).
+
+        Parses a JSON-RPC request, dispatches it synchronously, and returns
+        the response as application/json. This is the mode used by Glama's
+        inspector and any client built against the 2025-03-26 MCP spec.
+        Sessions and server-push are not supported in stateless mode.
+        """
+        ip = _client_ip(scope)
+        if not _check_rate_limit(ip):
+            body = json.dumps({"error": "Too Many Requests"}).encode()
+            await _send_response(send, 429, body)
+            return
+
+        try:
+            raw = await _read_body(receive)
+        except RuntimeError:
+            body = json.dumps({"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "Request body too large"}}).encode()
+            await _send_response(send, 413, body)
+            return
+        try:
+            message = json.loads(raw)
+        except Exception:
+            body = json.dumps({"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "Parse error"}}).encode()
+            await _send_response(send, 400, body)
+            return
+
+        response = await _handle_message(message)
+        if response is None:
+            # Notification — no body expected
+            await _send_response(send, 204, b"", content_type=b"application/json")
+            return
+
+        await _send_response(send, 200, json.dumps(response).encode())
+
     async def _handle_messages(scope: dict, receive: Any, send: Any) -> None:
         """POST /messages/ — receive JSON-RPC, route response to SSE stream."""
+        ip = _client_ip(scope)
+        if not _check_rate_limit(ip):
+            body = json.dumps({"error": "Too Many Requests"}).encode()
+            await _send_response(send, 429, body)
+            return
+
         qs = scope.get("query_string", b"").decode()
         params = _parse_qs(qs)
         session_id = params.get("sessionId", "")
@@ -886,10 +1042,18 @@ def _build_server(env: Any):
             path = scope.get("path", "")
             method = scope.get("method", "").upper()
 
+            # ── CORS preflight — must be first so browsers can reach any route ──
+            if method == "OPTIONS":
+                await _send_response(send, 204, b"", content_type=b"text/plain")
+                return
+
             if path == "/sse" and method == "GET":
                 await _handle_sse(scope, receive, send)
             elif path in ("/messages/", "/messages") and method == "POST":
                 await _handle_messages(scope, receive, send)
+            elif path == "/mcp" and method == "POST":
+                # Streamable HTTP transport (MCP spec 2025-03-26)
+                await _handle_mcp_post(scope, receive, send)
             else:
                 body = json.dumps({"error": "Not found"}).encode()
                 await _send_response(send, 404, body)

--- a/tests/eval/threshold_calibration.json
+++ b/tests/eval/threshold_calibration.json
@@ -1,0 +1,152 @@
+[
+  {"query": "set up Stripe subscriptions with webhooks and signature verification", "expected_skill_id": "stripe-integration", "relevance": "strong"},
+  {"query": "implement Stripe Checkout with subscription plans", "expected_skill_id": "stripe-integration", "relevance": "strong"},
+  {"query": "handle Stripe webhook events and verify signatures", "expected_skill_id": "stripe-integration", "relevance": "strong"},
+
+  {"query": "set up a Supabase database with row-level security", "expected_skill_id": "supabase-integration", "relevance": "strong"},
+  {"query": "add Supabase auth with OAuth and magic link login", "expected_skill_id": "supabase-integration", "relevance": "strong"},
+  {"query": "configure RLS policies in Supabase for multi-tenant access", "expected_skill_id": "supabase-integration", "relevance": "strong"},
+
+  {"query": "write pytest unit tests for a FastAPI endpoint", "expected_skill_id": "test-writer", "relevance": "strong"},
+  {"query": "add Jest tests for a React component with mocks", "expected_skill_id": "test-writer", "relevance": "strong"},
+  {"query": "generate Go test cases with table-driven tests", "expected_skill_id": "test-writer", "relevance": "strong"},
+
+  {"query": "containerize a Python app with a multi-stage Dockerfile", "expected_skill_id": "docker-containerization", "relevance": "strong"},
+  {"query": "set up Docker Compose for a web app with a database", "expected_skill_id": "docker-containerization", "relevance": "strong"},
+  {"query": "build a production Docker image with non-root user and health checks", "expected_skill_id": "docker-containerization", "relevance": "strong"},
+
+  {"query": "set up GitHub Actions CI/CD for a Python project", "expected_skill_id": "github-actions", "relevance": "strong"},
+  {"query": "create a workflow to build and push a Docker image on merge", "expected_skill_id": "github-actions", "relevance": "strong"},
+  {"query": "configure matrix builds and caching in GitHub Actions", "expected_skill_id": "github-actions", "relevance": "strong"},
+
+  {"query": "build a REST API with FastAPI and Pydantic v2 models", "expected_skill_id": "fastapi", "relevance": "strong"},
+  {"query": "add JWT authentication to a FastAPI application", "expected_skill_id": "fastapi", "relevance": "strong"},
+  {"query": "set up async SQLAlchemy with FastAPI dependency injection", "expected_skill_id": "fastapi", "relevance": "strong"},
+
+  {"query": "use the Anthropic Claude API with tool use and streaming", "expected_skill_id": "claude-api", "relevance": "strong"},
+  {"query": "implement prompt caching with the Anthropic SDK", "expected_skill_id": "claude-api", "relevance": "strong"},
+  {"query": "call Claude with extended thinking and batch processing", "expected_skill_id": "claude-api", "relevance": "strong"},
+
+  {"query": "call the OpenAI GPT-4o API with structured output", "expected_skill_id": "openai-api", "relevance": "strong"},
+  {"query": "use OpenAI function calling with tool definitions", "expected_skill_id": "openai-api", "relevance": "strong"},
+  {"query": "generate images with DALL-E 3 via the OpenAI API", "expected_skill_id": "openai-api", "relevance": "strong"},
+
+  {"query": "use the Google Gemini API with multimodal input", "expected_skill_id": "gemini-api", "relevance": "strong"},
+  {"query": "call Gemini with function calling and structured output", "expected_skill_id": "gemini-api", "relevance": "strong"},
+  {"query": "use Gemini 1.5 Pro with long context and document analysis", "expected_skill_id": "gemini-api", "relevance": "strong"},
+
+  {"query": "build a Next.js app with App Router and React Server Components", "expected_skill_id": "nextjs-best-practices", "relevance": "strong"},
+  {"query": "optimize images and fonts in Next.js App Router", "expected_skill_id": "nextjs-best-practices", "relevance": "strong"},
+  {"query": "set up data fetching patterns in Next.js with async params", "expected_skill_id": "nextjs-best-practices", "relevance": "strong"},
+
+  {"query": "implement React hooks with proper memoization and useCallback", "expected_skill_id": "react-best-practices", "relevance": "strong"},
+  {"query": "set up error boundaries and virtualization in React", "expected_skill_id": "react-best-practices", "relevance": "strong"},
+  {"query": "manage global state in React without Redux", "expected_skill_id": "react-best-practices", "relevance": "strong"},
+
+  {"query": "design a GraphQL schema with resolvers and DataLoader", "expected_skill_id": "graphql-api", "relevance": "strong"},
+  {"query": "prevent N+1 query problems with DataLoader in GraphQL", "expected_skill_id": "graphql-api", "relevance": "strong"},
+  {"query": "set up Apollo Client with a GraphQL backend", "expected_skill_id": "graphql-api", "relevance": "strong"},
+
+  {"query": "write TypeScript with generics and discriminated unions", "expected_skill_id": "typescript-patterns", "relevance": "strong"},
+  {"query": "use conditional types and branded types in TypeScript", "expected_skill_id": "typescript-patterns", "relevance": "strong"},
+  {"query": "configure a strict TypeScript tsconfig for a production project", "expected_skill_id": "typescript-patterns", "relevance": "strong"},
+
+  {"query": "deploy infrastructure to AWS using Terraform modules", "expected_skill_id": "terraform", "relevance": "strong"},
+  {"query": "set up Terraform remote state and workspaces", "expected_skill_id": "terraform", "relevance": "strong"},
+  {"query": "write Terraform for GCP with CI/CD integration", "expected_skill_id": "terraform", "relevance": "strong"},
+
+  {"query": "deploy a Python app to Cloudflare Workers", "expected_skill_id": "cloudflare-workers", "relevance": "strong"},
+  {"query": "use Cloudflare KV and D1 in a Workers application", "expected_skill_id": "cloudflare-workers", "relevance": "strong"},
+  {"query": "set up Cloudflare Workers AI with vectorize and R2", "expected_skill_id": "cloudflare-workers", "relevance": "strong"},
+
+  {"query": "write optimized SQL with CTEs and window functions", "expected_skill_id": "sql-query-writer", "relevance": "strong"},
+  {"query": "add indexes and analyze query execution plans in PostgreSQL", "expected_skill_id": "sql-query-writer", "relevance": "strong"},
+  {"query": "rewrite a slow SQL query to avoid common anti-patterns", "expected_skill_id": "sql-query-writer", "relevance": "strong"},
+
+  {"query": "extract text and tables from a PDF document programmatically", "expected_skill_id": "pdf-processing", "relevance": "strong"},
+  {"query": "fill a PDF form using Python with field detection", "expected_skill_id": "pdf-processing", "relevance": "strong"},
+  {"query": "merge and split PDF files with PyPDF", "expected_skill_id": "pdf-processing", "relevance": "strong"},
+
+  {"query": "create an Excel spreadsheet with charts and formulas using openpyxl", "expected_skill_id": "xlsx-creator", "relevance": "strong"},
+  {"query": "build a financial model in Excel with conditional formatting", "expected_skill_id": "xlsx-creator", "relevance": "strong"},
+  {"query": "generate a multi-sheet Excel report from Python data", "expected_skill_id": "xlsx-creator", "relevance": "strong"},
+
+  {"query": "create a Word document with tables and styles using python-docx", "expected_skill_id": "docx-creator", "relevance": "strong"},
+  {"query": "generate a professional report in DOCX format programmatically", "expected_skill_id": "docx-creator", "relevance": "strong"},
+  {"query": "add tracked changes and headers to a Word document", "expected_skill_id": "docx-creator", "relevance": "strong"},
+
+  {"query": "build a PowerPoint presentation with charts using pptxgenjs", "expected_skill_id": "pptx-creator", "relevance": "strong"},
+  {"query": "generate a slide deck from data with custom themes", "expected_skill_id": "pptx-creator", "relevance": "strong"},
+  {"query": "add images and design principles to a PPTX presentation", "expected_skill_id": "pptx-creator", "relevance": "strong"},
+
+  {"query": "perform exploratory data analysis on a CSV dataset", "expected_skill_id": "data-analysis", "relevance": "strong"},
+  {"query": "clean a dataframe and produce summary statistics and visualizations", "expected_skill_id": "data-analysis", "relevance": "strong"},
+  {"query": "analyze tabular data and generate actionable insights", "expected_skill_id": "data-analysis", "relevance": "strong"},
+
+  {"query": "scrape structured data from a paginated website with rate limiting", "expected_skill_id": "web-scraper", "relevance": "strong"},
+  {"query": "build a web scraper that handles bot detection and CAPTCHA", "expected_skill_id": "web-scraper", "relevance": "strong"},
+  {"query": "extract product listings from an e-commerce site with Playwright", "expected_skill_id": "web-scraper", "relevance": "strong"},
+
+  {"query": "write a detailed code review for a pull request with severity ratings", "expected_skill_id": "code-review", "relevance": "strong"},
+  {"query": "review a Python file for security issues and code quality", "expected_skill_id": "code-review", "relevance": "strong"},
+  {"query": "add CRITICAL and HIGH findings to a structured code review", "expected_skill_id": "code-review", "relevance": "strong"},
+
+  {"query": "integrate a REST API with authentication, pagination, and retry logic", "expected_skill_id": "api-integration", "relevance": "strong"},
+  {"query": "build an HTTP client with exponential backoff and error handling", "expected_skill_id": "api-integration", "relevance": "strong"},
+  {"query": "use an OpenAPI spec to generate a type-safe API client", "expected_skill_id": "api-integration", "relevance": "strong"},
+
+  {"query": "write a professional README with badges and usage examples", "expected_skill_id": "readme-writer", "relevance": "strong"},
+  {"query": "generate documentation for an open-source Python project", "expected_skill_id": "readme-writer", "relevance": "strong"},
+  {"query": "add API reference and contributing guide to a README", "expected_skill_id": "readme-writer", "relevance": "strong"},
+
+  {"query": "write better prompts for Claude using chain-of-thought techniques", "expected_skill_id": "llm-prompt-engineering", "relevance": "strong"},
+  {"query": "design a system prompt for an AI agent with tool use", "expected_skill_id": "llm-prompt-engineering", "relevance": "strong"},
+  {"query": "use few-shot examples and structured output in LLM prompts", "expected_skill_id": "llm-prompt-engineering", "relevance": "strong"},
+
+  {"query": "build an MCP server with FastMCP and Python tools", "expected_skill_id": "mcp-server-builder", "relevance": "strong"},
+  {"query": "create an MCP server with TypeScript SDK and resources", "expected_skill_id": "mcp-server-builder", "relevance": "strong"},
+  {"query": "add prompts and resource endpoints to a FastMCP server", "expected_skill_id": "mcp-server-builder", "relevance": "strong"},
+
+  {"query": "create a good-looking UI with typography and color palettes", "expected_skill_id": "frontend-design", "relevance": "strong"},
+  {"query": "add micro-animations and hover effects to a web page", "expected_skill_id": "frontend-design", "relevance": "strong"},
+  {"query": "choose a font system and visual hierarchy for a dashboard", "expected_skill_id": "frontend-design", "relevance": "strong"},
+
+  {"query": "build a self-contained interactive HTML artifact with React and Tailwind", "expected_skill_id": "web-artifacts-builder", "relevance": "strong"},
+  {"query": "create a D3 data visualization as a standalone HTML page", "expected_skill_id": "web-artifacts-builder", "relevance": "strong"},
+  {"query": "build an interactive dashboard in a single HTML file with no build step", "expected_skill_id": "web-artifacts-builder", "relevance": "strong"},
+
+  {"query": "write a conventional commit message from a git diff", "expected_skill_id": "git-commit-writer", "relevance": "strong"},
+  {"query": "generate a commit message with type, scope, and breaking changes", "expected_skill_id": "git-commit-writer", "relevance": "strong"},
+  {"query": "format a co-authored commit with conventional commits convention", "expected_skill_id": "git-commit-writer", "relevance": "strong"},
+
+  {"query": "hello world in Python", "expected_skill_id": null, "relevance": "none", "notes": "Basic programming, no skill needed"},
+  {"query": "what is a variable", "expected_skill_id": null, "relevance": "none", "notes": "Conceptual question, no procedural skill"},
+  {"query": "explain recursion", "expected_skill_id": null, "relevance": "none", "notes": "Conceptual, no skill"},
+  {"query": "how does the internet work", "expected_skill_id": null, "relevance": "none"},
+  {"query": "convert a list to a set in Python", "expected_skill_id": null, "relevance": "none"},
+  {"query": "sort a dictionary by value", "expected_skill_id": null, "relevance": "none"},
+  {"query": "write a for loop in JavaScript", "expected_skill_id": null, "relevance": "none"},
+  {"query": "what is a promise in JavaScript", "expected_skill_id": null, "relevance": "none"},
+  {"query": "calculate the median of a list", "expected_skill_id": null, "relevance": "none"},
+  {"query": "open a file in Python", "expected_skill_id": null, "relevance": "none"},
+  {"query": "parse a JSON string in JavaScript", "expected_skill_id": null, "relevance": "none"},
+  {"query": "add two numbers in Go", "expected_skill_id": null, "relevance": "none"},
+  {"query": "print a string to console in TypeScript", "expected_skill_id": null, "relevance": "none"},
+  {"query": "check if a string contains a substring", "expected_skill_id": null, "relevance": "none"},
+  {"query": "what is the difference between a list and a tuple", "expected_skill_id": null, "relevance": "none"},
+  {"query": "how do I install a Python package", "expected_skill_id": null, "relevance": "none"},
+  {"query": "what does git rebase do", "expected_skill_id": null, "relevance": "none"},
+  {"query": "rename a branch in git", "expected_skill_id": null, "relevance": "none"},
+  {"query": "what is a decorator in Python", "expected_skill_id": null, "relevance": "none"},
+  {"query": "what is the difference between == and === in JavaScript", "expected_skill_id": null, "relevance": "none"},
+  {"query": "format a date in Python", "expected_skill_id": null, "relevance": "none"},
+  {"query": "create a virtualenv in Python", "expected_skill_id": null, "relevance": "none"},
+  {"query": "what is dependency injection", "expected_skill_id": null, "relevance": "none"},
+  {"query": "how do I center a div in CSS", "expected_skill_id": null, "relevance": "none"},
+  {"query": "what is a REST API", "expected_skill_id": null, "relevance": "none"},
+  {"query": "use map and filter in JavaScript", "expected_skill_id": null, "relevance": "none"},
+  {"query": "write a regex to match an email address", "expected_skill_id": null, "relevance": "none"},
+  {"query": "what is memoization", "expected_skill_id": null, "relevance": "none"},
+  {"query": "what is the big O notation for binary search", "expected_skill_id": null, "relevance": "none"},
+  {"query": "explain the difference between TCP and UDP", "expected_skill_id": null, "relevance": "none"}
+]


### PR DESCRIPTION
Worker (src/worker.py):
- Add Streamable HTTP transport (POST /mcp, stateless JSON-RPC) for Glama/MCP Inspector compatibility
- Add CORS headers (Access-Control-Allow-Origin: *) and OPTIONS preflight handler to all responses
- Add per-IP sliding-window rate limiting (60 req/min default, configurable via RATE_LIMIT_RPM)
- Add skill version pinning: skills_get_body accepts optional version param and inline skill_id@version suffix
- Versioned body lookup with latest-fallback and version_note; deprecation_notice from frontmatter

Local server (skill_mcp/):
- models/skill.py: add deprecated and replaced_by fields to SkillFrontMatter and SkillRecord
- db/qdrant_manager.py: write versioned (skill_id@version) + latest-alias points on upsert; version_key keyword index; get_body_versioned(); get_frontmatter_payload()
- tools/get_skill_body.py: version pinning, inline suffix, fallback with version_note, deprecation_notice
- server.py: expose version parameter on skills_get_body tool

Calibration (new):
- skill_mcp/eval/__init__.py + calibrate.py: precision/recall/F1/specificity sweep over (t_high, t_low) pairs; --quiet CI mode; exit codes 0/1/2
- tests/eval/threshold_calibration.json: 120 eval triples (90 strong-match x 30 skills + 30 true negatives)
- Makefile: add calibrate and check-qdrant-keys targets
- requirements.txt: pin all deps to exact versions

Docs: update TRANSPARENCY.md, THREAT_MODEL.md (v1.2), ARCHITECTURE.md, README.md, VERSIONING.md, THRESHOLD_CALIBRATION.md to reflect implemented features