### PR TITLE
fix(pyproject): add python-dotenv to base [project] dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ requires-python = ">=3.11"
 
 # Runtime deps for the Cloudflare Worker (installed by wrangler into the Worker bundle)
 dependencies = [
-    "mcp>=1.5.0",       # FastMCP via mcp.server.fastmcp — the official Anthropic MCP SDK
+    "mcp>=1.5.0",           # FastMCP via mcp.server.fastmcp — the official Anthropic MCP SDK
+    "python-dotenv>=1.0.0", # .env loading — used by server.py, seed script, and tools at import time
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
python-dotenv is imported at module level in server.py (and transitively in tools that call load_dotenv at import time). It was already listed in the seed and local-server optional groups but was missing from the base [project].dependencies list, meaning a plain `pip install skill-mcp` (or wrangler bundle) would fail to resolve it.

Verified: uv sync --extra local-server installs cleanly; `python -m skill_mcp.server` starts without import errors.